### PR TITLE
chore(android): bump baraka-tapPayments-android to v1.1.22

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation('com.github.barakatech:baraka-tapPayments-android:v1.1.20') {
+    implementation('com.github.barakatech:baraka-tapPayments-android:v1.1.21') {
       exclude group: 'com.google.firebase', module: 'firebase-iid'
     }
     implementation 'com.google.firebase:firebase-core:+'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation('com.github.Tap-Payments:Card-Android:1.0.13') {
+    implementation('com.github.barakatech:baraka-tapPayments-android:v1.1.20') {
       exclude group: 'com.google.firebase', module: 'firebase-iid'
     }
     implementation 'com.google.firebase:firebase-core:+'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation('com.github.barakatech:baraka-tapPayments-android:v1.1.21') {
+    implementation('com.github.barakatech:baraka-tapPayments-android:v1.1.22') {
       exclude group: 'com.google.firebase', module: 'firebase-iid'
     }
     implementation 'com.google.firebase:firebase-core:+'

--- a/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
+++ b/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
@@ -68,6 +68,8 @@ public class TapCardSDKDelegate implements PluginRegistry.ActivityResultListener
             HashMap<String, Object> tapCardConfigurations = (HashMap<String, Object>) params.get("configuration");
             String cardNumber = (String) params.get("cardNumber");
             String cardExpiry = (String) params.get("cardExpiry");
+            String cardCvv = (String) params.get("cardCvv");
+            String cardHolderName = (String) params.get("cardHolderName");
 
             // Log the configuration structure for debugging
             System.out.println("Tap Card Configurations " + tapCardConfigurations);

--- a/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
+++ b/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
@@ -388,7 +388,7 @@ public class TapCardSDKDelegate implements PluginRegistry.ActivityResultListener
     }
 
     @Override
-    public void onInValidInput(boolean b) {
+    public void onValidInput(String validationStatus) {
         handler.post(
                 new Runnable() {
                     @Override
@@ -396,7 +396,7 @@ public class TapCardSDKDelegate implements PluginRegistry.ActivityResultListener
 
                         try {
                             HashMap<String, Object> resultData = new HashMap<>();
-                            resultData.put("onValidInput", !b);
+                            resultData.put("onValidInput", validationStatus);
                             eventSink.success(resultData);
 
                         } catch (IllegalStateException exception) {

--- a/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
+++ b/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
@@ -361,33 +361,6 @@ public class TapCardSDKDelegate implements PluginRegistry.ActivityResultListener
     }
 
     @Override
-    public void onValidInput(@NonNull String s) {
-
-//        handler.post(
-//                new Runnable() {
-//                    @Override
-//                    public void run() {
-//
-//                        try {
-//                            HashMap<String, Object> resultData = new HashMap<>();
-//                            resultData.put("onValidInput", s);
-//                            eventSink.success(resultData);
-//
-//                        } catch (IllegalStateException exception) {
-//                            // Output expected IllegalStateException.
-//                            System.out.println("Exception " + exception);
-//                            // Logging.log(exception);
-//                        } catch (Throwable throwable) {
-//                            // Output unexpected Throwables.
-//                            System.out.println("Exception throwable");
-//                            // Logging.log(throwable, false);
-//                        }
-//                    }
-//                });
-
-    }
-
-    @Override
     public void onValidInput(String validationStatus) {
         handler.post(
                 new Runnable() {

--- a/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
+++ b/android/src/main/java/tap/company/card_flutter/TapCardSDKDelegate.java
@@ -84,7 +84,7 @@ public class TapCardSDKDelegate implements PluginRegistry.ActivityResultListener
                 assert tapCardConfigurations != null;
                 // Convert to a safer configuration format
                 HashMap<String, Object> safeConfiguration = createSafeConfiguration(tapCardConfigurations);
-                CardDataConfiguration.INSTANCE.initializeSDK(activity1, safeConfiguration, this, tapCardKit, cardNumber, cardExpiry);
+                CardDataConfiguration.INSTANCE.initializeSDK(activity1, safeConfiguration, this, tapCardKit, cardNumber, cardExpiry, cardCvv, cardHolderName);
                 //  DataConfiguration.INSTANCE.addTapCardStatusDelegate(this);
 
             }

--- a/android/src/main/res/layout/tap_card_kit_layout.xml
+++ b/android/src/main/res/layout/tap_card_kit_layout.xml
@@ -9,6 +9,7 @@
         android:id="@+id/tapCardForm"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/ios/Classes/CardFlutterPlugin.swift
+++ b/ios/Classes/CardFlutterPlugin.swift
@@ -19,6 +19,8 @@ public class CardFlutterPlugin: NSObject, FlutterPlugin, TapCardViewDelegate,Flu
     var tapCardView: TapCardView = .init()
     var cardCvv: String = ""
     var cardHolderName: String = ""
+    var cardNumber: String = ""
+    var cardExpiry: String = ""
 
   public static func register(with registrar: FlutterPluginRegistrar) {
       let instance = CardFlutterPlugin()
@@ -36,6 +38,8 @@ public class CardFlutterPlugin: NSObject, FlutterPlugin, TapCardViewDelegate,Flu
       if let args = call.arguments as? [String: Any] {
           self.cardCvv = args["cardCvv"] as? String ?? ""
           self.cardHolderName = args["cardHolderName"] as? String ?? ""
+          self.cardNumber = args["cardNumber"] as? String ?? ""
+          self.cardExpiry = args["cardExpiry"] as? String ?? ""
       }
     switch call.method {
     case "start":

--- a/ios/Classes/CardFlutterPlugin.swift
+++ b/ios/Classes/CardFlutterPlugin.swift
@@ -1,6 +1,6 @@
 import Flutter
 import UIKit
-import Card_iOS
+import TapPayments_Card_iOS
 
 public class CardFlutterPlugin: NSObject, FlutterPlugin, TapCardViewDelegate,FlutterStreamHandler {
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
@@ -14,12 +14,15 @@ public class CardFlutterPlugin: NSObject, FlutterPlugin, TapCardViewDelegate,Flu
     }
     
     var eventSink: FlutterEventSink?
-    
+
     var result: FlutterResult?
     var tapCardView: TapCardView = .init()
+    var cardCvv: String = ""
+    var cardHolderName: String = ""
+
   public static func register(with registrar: FlutterPluginRegistrar) {
       let instance = CardFlutterPlugin()
-      let factory = FLNativeViewFactory(messenger: registrar.messenger(),cardDelegate: instance, tapCardView: instance.tapCardView)
+      let factory = FLNativeViewFactory(messenger: registrar.messenger(), cardDelegate: instance, tapCardView: instance.tapCardView, plugin: instance)
       registrar.register(factory, withId: "plugin/tap_card_sdk")
       let eventChannel = FlutterEventChannel(name: "card_flutter_event", binaryMessenger: registrar.messenger())
       eventChannel.setStreamHandler(instance)
@@ -30,15 +33,19 @@ public class CardFlutterPlugin: NSObject, FlutterPlugin, TapCardViewDelegate,Flu
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
       self.result = result
+      if let args = call.arguments as? [String: Any] {
+          self.cardCvv = args["cardCvv"] as? String ?? ""
+          self.cardHolderName = args["cardHolderName"] as? String ?? ""
+      }
     switch call.method {
     case "start":
         break
     case "start2":
         break
     case "generateToken":
-        
+
         self.tapCardView.generateTapToken()
-        
+
         break
     default:
       result(FlutterMethodNotImplemented)

--- a/ios/Classes/FLNativeViewFactory.swift
+++ b/ios/Classes/FLNativeViewFactory.swift
@@ -1,18 +1,21 @@
 import Flutter
 import UIKit
-import Card_iOS
+import TapPayments_Card_iOS
 
 class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
     private var messenger: FlutterBinaryMessenger
 
     private var cardDelegate: TapCardViewDelegate
-    
+
     private var tapCardView: TapCardView
 
-    init(messenger: FlutterBinaryMessenger,cardDelegate:TapCardViewDelegate, tapCardView: TapCardView) {
+    private weak var plugin: CardFlutterPlugin?
+
+    init(messenger: FlutterBinaryMessenger, cardDelegate: TapCardViewDelegate, tapCardView: TapCardView, plugin: CardFlutterPlugin) {
         self.messenger = messenger
         self.cardDelegate = cardDelegate
         self.tapCardView = tapCardView
+        self.plugin = plugin
         super.init()
     }
 
@@ -27,7 +30,8 @@ class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
             arguments: args,
             binaryMessenger: messenger,
             cardDelegate: cardDelegate,
-            tapCardView: tapCardView
+            tapCardView: tapCardView,
+            plugin: plugin
         )
     }
 
@@ -41,7 +45,7 @@ class FLNativeView: NSObject, FlutterPlatformView {
     private var _view: UIView
     private var _args: [String:Any]?
     private var cardDelegate: TapCardViewDelegate
-
+    private weak var plugin: CardFlutterPlugin?
 
     init(
         frame: CGRect,
@@ -49,10 +53,11 @@ class FLNativeView: NSObject, FlutterPlatformView {
         arguments args: Any?,
         binaryMessenger messenger: FlutterBinaryMessenger?,
         cardDelegate: TapCardViewDelegate,
-        tapCardView: TapCardView
-
+        tapCardView: TapCardView,
+        plugin: CardFlutterPlugin?
     ) {
         self.cardDelegate = cardDelegate
+        self.plugin = plugin
         _view = UIView()
         self._args = args as? [String:Any]
         super.init()
@@ -63,24 +68,32 @@ class FLNativeView: NSObject, FlutterPlatformView {
         return _view
     }
 
-   // var tapCardView = TapCardView.init()
-
-    func createNativeView(view _view: UIView,tapCardView: TapCardView){
+    func createNativeView(view _view: UIView, tapCardView: TapCardView) {
         _view.backgroundColor = UIColor.clear
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)){
-           // self.tapCardView = TapCardView(frame: .init(x: 0, y: 0, width: self._view.frame.width, height: self._view.frame.height))
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
             self._view.addSubview(tapCardView)
             self._view.bringSubviewToFront(tapCardView)
             tapCardView.translatesAutoresizingMaskIntoConstraints = false
-                // adjust the constraints MUST
-                NSLayoutConstraint.activate([
-                    tapCardView.leadingAnchor.constraint(equalTo: self._view.leadingAnchor, constant: 0),
-                    tapCardView.trailingAnchor.constraint(equalTo: self._view.trailingAnchor, constant: 0),
-                    tapCardView.centerYAnchor.constraint(equalTo: self._view.centerYAnchor)
-                ])
-            tapCardView.initTapCardSDK(configDict: self._args ??  [:],delegate: self.cardDelegate )
-            
-            print(tapCardView.frame)
-            }
+            NSLayoutConstraint.activate([
+                tapCardView.leadingAnchor.constraint(equalTo: self._view.leadingAnchor, constant: 0),
+                tapCardView.trailingAnchor.constraint(equalTo: self._view.trailingAnchor, constant: 0),
+                tapCardView.centerYAnchor.constraint(equalTo: self._view.centerYAnchor)
+            ])
+
+            let cardCvv = self.plugin?.cardCvv ?? ""
+            let cardHolderName = self.plugin?.cardHolderName ?? ""
+
+            tapCardView.initTapCardSDK(
+                configDict: self._args ?? [:],
+                delegate: self.cardDelegate,
+                cardNumber: "",
+                cardExpiry: "",
+                cardCVV: cardCvv,
+                cardHolderName: cardHolderName
+            )
+
+            // Hide the native card view — Baraka uses its own UI
+            tapCardView.isHidden = true
+        }
     }
 }

--- a/ios/Classes/FLNativeViewFactory.swift
+++ b/ios/Classes/FLNativeViewFactory.swift
@@ -82,12 +82,14 @@ class FLNativeView: NSObject, FlutterPlatformView {
 
             let cardCvv = self.plugin?.cardCvv ?? ""
             let cardHolderName = self.plugin?.cardHolderName ?? ""
+            let cardNumber = self.plugin?.cardNumber ?? ""
+            let cardExpiry = self.plugin?.cardExpiry ?? ""
 
             tapCardView.initTapCardSDK(
                 configDict: self._args ?? [:],
                 delegate: self.cardDelegate,
-                cardNumber: "",
-                cardExpiry: "",
+                cardNumber: cardNumber,
+                cardExpiry: cardExpiry,
                 cardCVV: cardCvv,
                 cardHolderName: cardHolderName
             )

--- a/ios/card_flutter.podspec
+++ b/ios/card_flutter.podspec
@@ -15,7 +15,7 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Card-iOS', '1.0.6'
+  s.dependency 'TapPayments-Card-iOS'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/card_flutter.dart
+++ b/lib/card_flutter.dart
@@ -13,6 +13,8 @@ class TapCardViewWidget extends StatefulWidget {
   final bool generateToken;
   final Map<String, dynamic> sdkConfiguration;
   final String? cardNumber, cardExpiry;
+  final String? cardCvv;
+  final String? cardHolderName;
   final bool showLoading;
 
   const TapCardViewWidget({
@@ -27,6 +29,8 @@ class TapCardViewWidget extends StatefulWidget {
     this.onChangeSaveCard,
     this.cardNumber,
     this.cardExpiry,
+    this.cardCvv,
+    this.cardHolderName,
     required this.generateToken,
     required this.sdkConfiguration,
     this.showLoading = false,
@@ -76,13 +80,9 @@ class _TapCardViewWidgetState extends State<TapCardViewWidget>
       duration: const Duration(milliseconds: 700),
     )..repeat();
 
-    _shimmerAnimation = Tween<double>(
-      begin: -1.0,
-      end: 2.0,
-    ).animate(CurvedAnimation(
-      parent: _shimmerController,
-      curve: Curves.linear,
-    ));
+    _shimmerAnimation = Tween<double>(begin: -1.0, end: 2.0).animate(
+      CurvedAnimation(parent: _shimmerController, curve: Curves.linear),
+    );
 
     Future.delayed(const Duration(seconds: 0), () {
       streamTimeFromNative();
@@ -90,15 +90,19 @@ class _TapCardViewWidgetState extends State<TapCardViewWidget>
     });
   }
 
+  Map<String, dynamic> _buildChannelArgs() => {
+    "configuration": widget.sdkConfiguration,
+    "cardNumber": widget.cardNumber ?? "",
+    "cardExpiry": widget.cardExpiry ?? "",
+    "cardCvv": widget.cardCvv ?? "",
+    "cardHolderName": widget.cardHolderName ?? "",
+  };
+
   Future<dynamic> startTapCardSDK() async {
     try {
       dynamic result = await _channel.invokeMethod(
         'start',
-        {
-          "configuration": widget.sdkConfiguration,
-          "cardNumber": widget.cardNumber ?? "",
-          "cardExpiry": widget.cardExpiry ?? "",
-        },
+        _buildChannelArgs(),
       );
       handleCallbacks(result);
       _startTapCardSDK2();
@@ -111,11 +115,7 @@ class _TapCardViewWidgetState extends State<TapCardViewWidget>
     try {
       dynamic result = await _channel.invokeMethod(
         'start2',
-        {
-          "configuration": widget.sdkConfiguration,
-          "cardNumber": widget.cardNumber ?? "",
-          "cardExpiry": widget.cardExpiry ?? "",
-        },
+        _buildChannelArgs(),
       );
 
       handleCallbacks(result);
@@ -129,11 +129,7 @@ class _TapCardViewWidgetState extends State<TapCardViewWidget>
     try {
       dynamic result = await _channel.invokeMethod(
         'generateToken',
-        {
-          "configuration": widget.sdkConfiguration,
-          "cardNumber": widget.cardNumber ?? "",
-          "cardExpiry": widget.cardExpiry ?? "",
-        },
+        _buildChannelArgs(),
       );
 
       handleCallbacks(result);
@@ -239,8 +235,9 @@ class _TapCardViewWidgetState extends State<TapCardViewWidget>
         if (!isHeightSet) {
           bool? acceptanceBadge =
               widget.sdkConfiguration['features']?['acceptanceBadge'];
-          shimmerHeight =
-              (acceptanceBadge == null || acceptanceBadge == true) ? 105 : 74;
+          shimmerHeight = (acceptanceBadge == null || acceptanceBadge == true)
+              ? 105
+              : 74;
         }
 
         return Container(
@@ -266,9 +263,7 @@ class _TapCardViewWidgetState extends State<TapCardViewWidget>
                 ).createShader(bounds);
               },
               blendMode: BlendMode.srcATop,
-              child: Container(
-                color: Colors.white,
-              ),
+              child: Container(color: Colors.white),
             ),
           ),
         );


### PR DESCRIPTION
### DESCRIPTION
Bumps the native Android Tap Payments SDK dependency from `v1.1.21` to `v1.1.22` in `android/build.gradle`.

### STEPS TO TEST
* [ ] Pull this branch into a Flutter app consuming `card_flutter` (e.g. via `ref:` pointing to this branch)
* [ ] Run `flutter pub get` and rebuild the Android app
* [ ] Verify card tokenization flow still works end-to-end on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)