### PR TITLE
Fix Android build on AGP 9.x / Gradle 9.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.22 24-06-2026
+
+* Fix Android build failure on AGP 9.x / Gradle 9.6+:
+  * Remove unsupported `jcenter()` repositories (caused "Could not find method jcenter()").
+  * Stop pinning the Android Gradle Plugin in the plugin's `buildscript`; AGP is now
+    provided by the consuming app, so the plugin works with AGP 8.x and 9.x. The
+    previously pinned AGP 8.13.2 is incompatible with Gradle 9.6+ and broke AGP 9 clients.
+  * Use `compileSdk` / `minSdk` (the `*Version` forms are removed in AGP 9).
+  * Set `namespace` unconditionally (required since AGP 8).
+  * Verified against AGP 8.13.2/Gradle 8.14.3 and AGP 9.2.1/Gradle 9.6.1.
+
 ## 1.0.21 23-06-2026
 
 * Security: upgrade outdated Android build components flagged by security review.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,26 +1,15 @@
 group 'tap.company.card_flutter'
 version '1.0'
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        jcenter()
-        maven { url 'https://jitpack.io' }
-
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath 'com.google.gms:google-services:4.3.15'
-    }
-}
+// NOTE: This plugin intentionally does NOT pin its own Android Gradle Plugin
+// version. AGP is provided by the consuming app, so the plugin works with
+// whatever AGP the app uses (8.x or 9.x). Pinning AGP here previously forced
+// AGP 8.13.2, which is incompatible with Gradle 9.6+ and broke AGP 9 clients.
 
 rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { url 'https://jitpack.io' }
 
     }
@@ -31,11 +20,9 @@ apply plugin: 'com.android.library'
 
 
 android {
-    if (project.android.hasProperty("namespace")) {
-        namespace 'tap.company.card_flutter'
-    }
+    namespace 'tap.company.card_flutter'
 
-    compileSdkVersion 35
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
@@ -43,7 +30,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 24
+        minSdk 24
     }
 
     dependencies {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: card_flutter
 description: Accept a payment with one or multiple payment methods securely. Powered by Tap Payments.
-version: 1.0.21
+version: 1.0.22
 homepage: https://github.com/Tap-Payments/Card-Flutter
 
 environment:


### PR DESCRIPTION
Client builds on AGP 9 / Gradle 9.6 failed with
"Could not find method jcenter()" and, after that, an AGP 8.x vs
Gradle 9.6 InternalProblems incompatibility.

- Remove unsupported jcenter() repositories (use mavenCentral)
- Stop pinning AGP in the plugin buildscript; inherit the app's AGP
  so the plugin works with AGP 8.x AND 9.x (pinned 8.13.2 is
  incompatible with Gradle 9.6+)
- compileSdkVersion -> compileSdk, minSdkVersion -> minSdk
- Set namespace unconditionally (required since AGP 8)
- Version 1.0.21 -> 1.0.22

Verified both ways:
- example app: AGP 8.13.2 / Gradle 8.14.3 -> builds
- standalone harness: AGP 9.2.1 / Gradle 9.6.1 -> BUILD SUCCESSFUL

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
